### PR TITLE
+ counts for electrons and positrons

### DIFF
--- a/src/particle.rs
+++ b/src/particle.rs
@@ -15,22 +15,24 @@ pub struct ActiveParticles {
     pub total: u32,
 }
 
-fn increase_particle_count(mut particle_count: ResMut<ActiveParticles>, mut charge: f32)
+fn increase_particle_count(mut particle_count: ResMut<ActiveParticles>, mut charge: f32) -> ResMut<ActiveParticles>
 {
     if charge < 0.
     {particle_count.electrons += 1;}
     else
     {particle_count.positrons += 1;}
     particle_count.total = particle_count.positrons + particle_count.electrons;
+    particle_count
 }
 
-fn decrease_particle_count(mut particle_count: ResMut<ActiveParticles>, mut charge: f32)
+fn decrease_particle_count( mut particle_count: ResMut<ActiveParticles>, mut charge: f32) -> ResMut<ActiveParticles>
 {
     if charge < 0.
     {particle_count.electrons -= 1;}
     else
     {particle_count.positrons -= 1;}
     particle_count.total = particle_count.positrons + particle_count.electrons;
+    particle_count
 }
 
 pub struct ParticlePlugin;
@@ -66,6 +68,7 @@ fn particle_spawn(
         let mut rng = thread_rng();
         let mut charge_bool = rng.gen::<bool>();
 
+        #[warn(clippy::if_same_then_else)]
         if particle_count.positrons == MAX_NUM_PARTICLES -1
         {
             charge_bool = false; // force next particle --> electron
@@ -85,7 +88,7 @@ fn particle_spawn(
             charge = -1.;
             sprite_file = ELECTRON_SPRITE;
           }
-        increase_particle_count(particle_count, charge);
+          particle_count = increase_particle_count(particle_count, charge);
 
         // slow init vel so as to not kill player immediatly on spawn
         let vel = Vec3::new(
@@ -272,8 +275,8 @@ pub fn particle_particle_collision_system(
                 commands.entity(id2).despawn();
 
                 // update counts
-                decrease_particle_count(particle_count, p1.charge);
-                decrease_particle_count(particle_count, p2.charge);
+                particle_count = decrease_particle_count(particle_count, p1.charge);
+                particle_count = decrease_particle_count(particle_count, p2.charge);
 
             }
         }

--- a/src/particle.rs
+++ b/src/particle.rs
@@ -88,7 +88,9 @@ fn particle_spawn(
             charge = -1.;
             sprite_file = ELECTRON_SPRITE;
           }
+          info!("particle_count before increase = {:?}, {:?}", particle_count.electrons, particle_count.positrons);
           particle_count = increase_particle_count(particle_count, charge);
+          info!("particle_count after increase = {:?}, {:?}", particle_count.electrons, particle_count.positrons);
 
         // slow init vel so as to not kill player immediatly on spawn
         let vel = Vec3::new(
@@ -275,8 +277,10 @@ pub fn particle_particle_collision_system(
                 commands.entity(id2).despawn();
 
                 // update counts
+                info!("particle_count before decrease by 2 = {:?}, {:?}", particle_count.electrons, particle_count.positrons);
                 particle_count = decrease_particle_count(particle_count, p1.charge);
                 particle_count = decrease_particle_count(particle_count, p2.charge);
+                info!("particle_count after decrease by 2 = {:?}, {:?}", particle_count.electrons, particle_count.positrons);
 
             }
         }

--- a/src/particle.rs
+++ b/src/particle.rs
@@ -9,13 +9,35 @@ use rand::{random, thread_rng, Rng};
 
 use crate::constants::*;
 
-pub struct ActiveParticles(u32);
+pub struct ActiveParticles {
+    pub positrons: u32,
+    pub electrons: u32,
+    pub total: u32,
+}
+
+fn increase_particle_count(mut particle_count: ResMut<ActiveParticles>, mut charge: f32)
+{
+    if charge < 0.
+    {particle_count.electrons += 1;}
+    else
+    {particle_count.positrons += 1;}
+    particle_count.total = particle_count.positrons + particle_count.electrons;
+}
+
+fn decrease_particle_count(mut particle_count: ResMut<ActiveParticles>, mut charge: f32)
+{
+    if charge < 0.
+    {particle_count.electrons -= 1;}
+    else
+    {particle_count.positrons -= 1;}
+    particle_count.total = particle_count.positrons + particle_count.electrons;
+}
 
 pub struct ParticlePlugin;
 
 impl Plugin for ParticlePlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
-        app.insert_resource(ActiveParticles(0))
+        app.insert_resource(ActiveParticles{positrons:0, electrons:0, total:0})
             .add_system_set(
                 SystemSet::new()
                     .with_run_criteria(FixedTimestep::step(0.3))
@@ -31,23 +53,44 @@ impl Plugin for ParticlePlugin {
     }
 }
 
+
+
+
+
 fn particle_spawn(
     mut commands: Commands,
-    mut active_particles: ResMut<ActiveParticles>,
+    mut particle_count: ResMut<ActiveParticles>,
     asset_server: Res<AssetServer>,
 ) {
-    if active_particles.0 < MAX_NUM_PARTICLES {
+    if particle_count.total < MAX_NUM_PARTICLES {
         let mut rng = thread_rng();
-        let charge_bool = rng.gen::<bool>();
-        let charge = if charge_bool { 1. } else { -1. };
-        let sprite_file = if charge_bool {
-            POSITRON_SPRITE
-        } else {
-            ELECTRON_SPRITE
-        };
+        let mut charge_bool = rng.gen::<bool>();
+
+        if particle_count.positrons == MAX_NUM_PARTICLES -1
+        {
+            charge_bool = false; // force next particle --> electron
+        }
+        else if particle_count.electrons == MAX_NUM_PARTICLES -1
+        {
+            charge_bool = false; // force next particle --> positron
+        }
+
+        let mut charge = 0. ;
+        let mut sprite_file = "";
+        if charge_bool {
+            charge = 1.;
+            sprite_file = POSITRON_SPRITE;
+         }
+         else {
+            charge = -1.;
+            sprite_file = ELECTRON_SPRITE;
+          }
+        increase_particle_count(particle_count, charge);
+
+        // slow init vel so as to not kill player immediatly on spawn
         let vel = Vec3::new(
-            rng.gen_range(-1.0..1.0) as f32,
-            rng.gen_range(-1.0..1.0) as f32,
+            rng.gen_range(-0.1..0.1) as f32,
+            rng.gen_range(-0.1..0.1) as f32,
             0.,
         )
         .normalize()
@@ -72,8 +115,7 @@ fn particle_spawn(
                 mass: 1.,
             })
             .insert(Collider::Particle);
-        active_particles.0 += 1;
-        info!("Added another particle (now {:?})", active_particles.0)
+
     }
 }
 
@@ -189,7 +231,7 @@ pub fn particle_wall_collision_system(
 
 pub fn particle_particle_collision_system(
     mut commands: Commands,
-    mut active_particles: ResMut<ActiveParticles>,
+    mut particle_count: ResMut<ActiveParticles>,
     mut app_exit_events: ResMut<Events<bevy::app::AppExit>>,
     sprite_infos: Res<SpriteInfos>,
     mut scoreboard: ResMut<Scoreboard>,
@@ -222,15 +264,17 @@ pub fn particle_particle_collision_system(
                     info!("END GAME");
                     app_exit_events.send(AppExit);
                 } else {
-                    // info!("INCREASE SCORE");
                     scoreboard.score += 1;
                     info!("INCREASE SCORE = {}", scoreboard.score);
-
                 }
-
+                // delete particles
                 commands.entity(id1).despawn();
                 commands.entity(id2).despawn();
-                active_particles.0 -= 2; // this will allow more to spawn
+
+                // update counts
+                decrease_particle_count(particle_count, p1.charge);
+                decrease_particle_count(particle_count, p2.charge);
+
             }
         }
     }


### PR DESCRIPTION
Close #26 

Atm i get an error! 
```rust
   Compiling global_game_jam_2022 v0.1.0 (/Users/avaj0001/Documents/personal/rust/global_game_jam_2022)
error[E0382]: use of moved value: `particle_count`
   --> src/particle.rs:275:41
    |
234 |     mut particle_count: ResMut<ActiveParticles>,
    |     ------------------ move occurs because `particle_count` has type `bevy::prelude::ResMut<'_, ActiveParticles>`, which does not implement the `Copy` trait
...
275 |                 decrease_particle_count(particle_count, p1.charge);
    |                                         ^^^^^^^^^^^^^^ value used here after move
276 |                 decrease_particle_count(particle_count, p2.charge);
    |                                         -------------- value moved here, in previous iteration of loop

error[E0382]: use of moved value: `particle_count`
   --> src/particle.rs:276:41
    |
234 |     mut particle_count: ResMut<ActiveParticles>,
    |     ------------------ move occurs because `particle_count` has type `bevy::prelude::ResMut<'_, ActiveParticles>`, which does not implement the `Copy` trait
...
275 |                 decrease_particle_count(particle_count, p1.charge);
    |                                         -------------- value moved here
276 |                 decrease_particle_count(particle_count, p2.charge);
    |                                         ^^^^^^^^^^^^^^ value used here after move

For more information about this error, try `rustc --explain E0382`.
error: could not compile `global_game_jam_2022` due to 2 previous errors
```